### PR TITLE
Sync monorepo state at f2a103f80b0140a59930ba9397f3884464dd6504

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout source code
         uses: actions/checkout@v3


### PR DESCRIPTION
NOTE: merging this PR does not automatically release a new version of the Terraform provider. You need to choose a new version number using semver and tag the latest master once merged:
```
git tag v0.0.0 && git push origin v0.0.0
```