### PR TITLE
Sync monorepo state at "Upgrade to latest go 1.20 minor version - 1.20.10 + log go version in GHA"

### DIFF
--- a/.github/actions/go-setup/action.yml
+++ b/.github/actions/go-setup/action.yml
@@ -7,6 +7,9 @@ runs:
       uses: actions/setup-go@v4
       with:
         go-version-file: go.mod
+    - name: Log go version
+      shell: bash
+      run: go version
     - name: Update PATH
       shell: bash
       run: |


### PR DESCRIPTION
Syncing from userclouds/userclouds@b4bdf3d29b2683c33018411116dec7c6eee48d88