### PR TITLE
Sync monorepo state at "Return HTTP 409 instead of a HTTP 500 in case of a DB unique violation"

### DIFF
--- a/openapi/userstore.yaml
+++ b/openapi/userstore.yaml
@@ -1266,6 +1266,8 @@ paths:
           description: Bad Request
         "404":
           description: Not Found
+        "409":
+          description: Conflict
         "500":
           description: Internal Server Error
       summary: Update Purpose


### PR DESCRIPTION
Syncing from userclouds/userclouds@c28092c32a815c16e51ba5166e30bcc8af810a35