### PR TITLE
Sync monorepo state at "Bump github.com/beevik/etree from 1.3.0 to 1.4.1"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/userclouds/terraform-provider-userclouds
 
-go 1.21
+go 1.21.0
 
 toolchain go1.22.2
 


### PR DESCRIPTION
Syncing from userclouds/userclouds@727e4df856bf8d9f4eaf428db7089f021ef9391e